### PR TITLE
Fix problem with the extension installation for Visual Studio 2019

### DIFF
--- a/ReferencesResolverExtension/source.extension.vsixmanifest
+++ b/ReferencesResolverExtension/source.extension.vsixmanifest
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="48e79884-e68f-41e3-8260-99660e5f76c9" Version="1.5.2" Language="en-US" Publisher="deyan.yosifov@telerik.com" />
+    <Identity Id="48e79884-e68f-41e3-8260-99660e5f76c9" Version="1.5.3" Language="en-US" Publisher="deyan.yosifov@telerik.com" />
     <DisplayName>ReferencesResolverExtension</DisplayName>
-    <Description>This extension allows you to easily add/remove multiple references to some project.</Description>
+    <Description>This extension allows you to easily add/remove multiple references to some projects.</Description>
   </Metadata>
   <Installation InstalledByMsi="false">
-    <InstallationTarget Version="[11.0,)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[11.0,)" Id="Microsoft.VisualStudio.Ultimate" />
-    <InstallationTarget Version="[11.0,)" Id="Microsoft.VisualStudio.Premium" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Ultimate" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Premium" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -18,6 +18,6 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Currently the extension states that it requires older version of the editor, which is not present in VS 2019, so the installation fails.