### PR TITLE
VS2019 Fix: Downgraded the NewtonSoft.Json in order to work correctly with .Net Core projects

### DIFF
--- a/ReferencesResolverExtension/ReferencesResolverExtension.csproj
+++ b/ReferencesResolverExtension/ReferencesResolverExtension.csproj
@@ -131,8 +131,8 @@
       <Private>True</Private>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>

--- a/ReferencesResolverExtension/ReferencesResolverExtensionPackage.cs
+++ b/ReferencesResolverExtension/ReferencesResolverExtensionPackage.cs
@@ -46,6 +46,7 @@ namespace Telerik.ReferencesResolverExtension
 
         static ReferencesResolverExtensionPackage()
         {
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings { MaxDepth = 128 };
             AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
 
             DefaultUserSettings = new UserSettingsModel()

--- a/ReferencesResolverExtension/packages.config
+++ b/ReferencesResolverExtension/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Extended.Wpf.Toolkit" version="2.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
   <package id="VSSDK.DTE" version="7.0.4" targetFramework="net45" />
   <package id="VSSDK.GraphModel" version="11.0.4" targetFramework="net45" />
   <package id="VSSDK.IDE" version="7.0.4" targetFramework="net45" />


### PR DESCRIPTION
closes #4