### PR TITLE
Publishing first version of ReferencesResolverExtension V2

### DIFF
--- a/ReferencesResolverExtension/source.extension.vsixmanifest
+++ b/ReferencesResolverExtension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="48e79884-e68f-41e3-8260-99660e5f76c9" Version="2.0.0" Language="en-US" Publisher="deyan.yosifov@progress.com" />
+        <Identity Id="48e79884-e68f-41e3-8260-99660e5f76c2" Version="2.0.0" Language="en-US" Publisher="Deyan Yosifov" />
         <DisplayName>ReferencesResolverExtension V2</DisplayName>
         <Description>This extension allows you to easily add/remove multiple references to some projects. V2 supports Visual Studio 2022 and above.</Description>
     </Metadata>


### PR DESCRIPTION
Changing the publisher value and the extension id so that it does not collide with the old extension id and the publisher matches the marketplace publisher name. With these changes version 2.0.0 is successfully uploaded as a new extension called ReferencesResolverExtension V2.